### PR TITLE
Add missing GM screen texts, add macro util to toggle GM screen

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -96,7 +96,9 @@
     "ActionCancelled": "Content import aborted",
     "UnsupportedContentType": "This type of content cannot be imported this way. You may try inserting it manually via UUID",
     "FailedToInsertContent": "Failed to insert content.",
-    "EditorSaved": "Successfully saved content to tab"
+    "EditorSaved": "Successfully saved content to tab",
+    "ShowMore": "Show More",
+    "LoadMore": "Load More"
   
   },
   "TCB_SETTINGS": {

--- a/src/module/chat-buttons/gm-screen.js
+++ b/src/module/chat-buttons/gm-screen.js
@@ -90,6 +90,9 @@ class GMScreen {
       return;
     }
 
+    window[SETTINGS.WINDOW_MODULE_NAME] = {
+      toggleGMScreen: this.toggleGMScreen.bind(this)
+    }
     const gmScreenBtn = $(`<a class="tcb-gm-screen-button" title="${game.i18n.localize('TCB_GMSCREEN.ToggleGMScreen')}">
       <i class="fas fa-book-open"></i>
     </a>`);

--- a/src/module/settings.js
+++ b/src/module/settings.js
@@ -2,6 +2,7 @@ import { GM_SCREEN_PRESETS } from '../templates/gm-screen-presets.js';
 
 export const SETTINGS = {
   MODULE_NAME: 'trinium-chat-buttons',
+  WINDOW_MODULE_NAME: 'triniumChatButtons',
 
   PRIVACY_VISIBILITY: 'privacyButtonVisibility',
   MIDI_BUTTON_VISIBILITY: 'midiButtonVisibility',


### PR DESCRIPTION
Some fixes from my own fork where I only care about the GM screen:
* `window.triniumChatButtons.toggleGMScreen()` can be used in macros to open/close gm screen.
* Show more/load more text in the gm screen have values set